### PR TITLE
Fixes for GNOME Shell 3.14

### DIFF
--- a/require.js
+++ b/require.js
@@ -9,7 +9,7 @@ const Gio = imports.gi.Gio;
 let gnomeShellJSLibs = {
     "extensionPrefs": "/usr/share/gnome-shell/js/",
     "gdm": "/usr/share/gnome-shell/js/",
-    "misc": "/usr/share/gnome-shell/js/",
+    "misc": "resource:///org/gnome/shell/misc/",
     "perf": "/usr/share/gnome-shell/js/",
     "ui": "/usr/share/gnome-shell/js/",
     "ui/components": "/usr/share/gnome-shell/js/ui/",
@@ -20,7 +20,7 @@ let gnomeShellJSLibs = {
     "getttext": "/usr/share/gjs-1.0/",
     "jsUnit": "/usr/share/gjs-1.0/",
     "lang": "/usr/share/gjs-1.0/",
-    "mainloop": "/usr/share/gjs-1.0/",
+    "mainloop": "resource:///org/gnome/gjs/modules/",
     "promise": "/usr/share/gjs-1.0/",
     "signals": "/usr/share/gjs-1.0/"
 };

--- a/test/testRequire.js
+++ b/test/testRequire.js
@@ -116,18 +116,6 @@ function test_require_gi_Gtk() {
     );
 }
 
-function test_require_misc() {
-    JSUnit.assertNotUndefined("It should require global module misc", require("misc"));
-    JSUnit.assertTrue(
-        "It should require global module misc.params.parse",
-        typeof require("misc/params/parse") == "function"
-    );
-    JSUnit.assertTrue(
-        "It should require global module misc.params.parse",
-        typeof require("misc/params").parse == "function"
-    );
-}
-
 function tearDown() {
     imports.searchPath = [];
 }


### PR DESCRIPTION
- Fixes almost all tests under GNOME Shell 3.14.
- Removes `misc' test as the module is no longer supplied.
- Additional paths, via `resource' schemas, may be required for
  more complex projects using modules not tested here.
